### PR TITLE
fix: per year bug fixes

### DIFF
--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/CveCommand.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/CveCommand.java
@@ -282,7 +282,7 @@ public class CveCommand extends AbstractNvdCommand {
         // will hold all entries that have been changed within the last8 days across all years
         List<DefCveItem> recentlyChangedEntries = new ArrayList<>();
 
-        for (int currentYear = START_YEAR; currentYear <= Year.now().getValue(); currentYear++) {
+        for (int currentYear = EARLIEST_CVE_YEAR; currentYear <= Year.now().getValue(); currentYear++) {
 
             // Be forgiving, if we fail to fetch a year, we just continue with the next one
             try {
@@ -290,7 +290,7 @@ public class CveCommand extends AbstractNvdCommand {
                 apiBuilder.removeLastModifiedFilter();
                 apiBuilder.removePublishDateFilter();
 
-                Path cacheFilePath = buildCacheTargetFile(properties, String.valueOf(currentYear));
+                Path cacheFilePath = buildCacheTargetFile(properties, currentYear);
                 LOG.info("INFO *** Processing year {} ***", currentYear);
                 CvesNvdPojo existingCacheData = loadExistingCacheAndConfigureApi(apiBuilder, currentYear,
                         cacheFilePath);
@@ -310,7 +310,7 @@ public class CveCommand extends AbstractNvdCommand {
                 if (cvesForYear.lastUpdated != null) {
                     properties.set("lastModifiedDate", cvesForYear.lastUpdated);
                 }
-                storeToCache(String.valueOf(currentYear), cvesForYear, properties);
+                storeToCache(currentYear, cvesForYear, properties);
                 LOG.info("INFO *** Finished year {} with #{} entries ***", currentYear,
                         cvesForYear.vulnerabilities.size());
 
@@ -397,6 +397,14 @@ public class CveCommand extends AbstractNvdCommand {
         }
 
         return finalResult;
+    }
+
+    private void storeToCache(int year, CvesNvdPojo cves, CacheProperties properties) {
+        int target = year;
+        if (target < START_YEAR) {
+            target = START_YEAR;
+        }
+        storeToCache(String.valueOf(target), cves, properties);
     }
 
     /**
@@ -514,6 +522,14 @@ public class CveCommand extends AbstractNvdCommand {
 
         return ZonedDateTime.ofInstant(Instant.ofEpochMilli(cacheFile.getAbsoluteFile().lastModified()),
                 ZoneOffset.UTC);
+    }
+
+    private Path buildCacheTargetFile(CacheProperties properties, int year) {
+        int target = year;
+        if (target < START_YEAR) {
+            target = START_YEAR;
+        }
+        return buildCacheTargetFile(properties, String.valueOf(target));
     }
 
     private Path buildCacheTargetFile(CacheProperties properties, String target) {

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/CveCommand.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/CveCommand.java
@@ -72,6 +72,7 @@ public class CveCommand extends AbstractNvdCommand {
      * Start year (until today) to cache CVEs for.
      */
     private static final int START_YEAR = 2002;
+    private static final int EARLIEST_CVE_YEAR = 1988;
 
     // FIXME - get format and version from API
     private static final String FORMAT = "NVD_CVE";
@@ -289,7 +290,7 @@ public class CveCommand extends AbstractNvdCommand {
                 apiBuilder.removeLastModifiedFilter();
                 apiBuilder.removePublishDateFilter();
 
-                Path cacheFilePath = buildCacheTargetFileForYear(properties, currentYear);
+                Path cacheFilePath = buildCacheTargetFile(properties, String.valueOf(currentYear));
                 LOG.info("INFO *** Processing year {} ***", currentYear);
                 CvesNvdPojo existingCacheData = loadExistingCacheAndConfigureApi(apiBuilder, currentYear,
                         cacheFilePath);
@@ -309,7 +310,7 @@ public class CveCommand extends AbstractNvdCommand {
                 if (cvesForYear.lastUpdated != null) {
                     properties.set("lastModifiedDate", cvesForYear.lastUpdated);
                 }
-                storeEntireYearToCache(currentYear, cvesForYear, properties);
+                storeToCache(String.valueOf(currentYear), cvesForYear, properties);
                 LOG.info("INFO *** Finished year {} with #{} entries ***", currentYear,
                         cvesForYear.vulnerabilities.size());
 
@@ -384,7 +385,9 @@ public class CveCommand extends AbstractNvdCommand {
             CvesNvdPojo currentResult = fetchFromNVDApi(apiBuilder);
 
             // update our last updated, since we crawl up the year, this will be the most recent in the end
-            finalResult.lastUpdated = currentResult.lastUpdated;
+            if (finalResult.lastUpdated == null || (currentResult.lastUpdated != null && finalResult.lastUpdated.isBefore(currentResult.lastUpdated))) {
+                finalResult.lastUpdated = currentResult.lastUpdated;
+            }
             // aggregate all results
             finalResult.vulnerabilities.addAll(currentResult.vulnerabilities);
 
@@ -399,9 +402,9 @@ public class CveCommand extends AbstractNvdCommand {
      * Given the CVEs for the year, stores all of them in a json cache file and a meta-dat file. creates
      * nvdcve-$year.json.gz and nvdcve-$year.meta
      */
-    private void storeEntireYearToCache(int year, CvesNvdPojo cves, CacheProperties properties) {
+    private void storeToCache(String target, CvesNvdPojo cves, CacheProperties properties) {
         ZonedDateTime lastChanged = Objects.requireNonNullElseGet(cves.lastUpdated, ZonedDateTime::now);
-        properties.set("lastModifiedDate." + year, lastChanged);
+        properties.set("lastModifiedDate." + target, lastChanged);
         int size = cves.vulnerabilities.size();
         MessageDigest md = getDigestAlg();
 
@@ -410,11 +413,11 @@ public class CveCommand extends AbstractNvdCommand {
 
         // save vulnerabilities into cache
         CveApiJson20 data = new CveApiJson20(size, 0, size, FORMAT, VERSION, lastChanged, cves.vulnerabilities);
-        final File cacheFile = buildCacheTargetFileForYear(properties, year).toFile();
+        final File cacheFile = buildCacheTargetFile(properties, target).toFile();
         long uncompressedSize = saveCvesToCache(cacheFile, data, md);
 
         // save meta data
-        final File metaDataFile = buildMetaDataTargetFileForYear(properties, year).toFile();
+        final File metaDataFile = buildMetaDataTargetFile(properties, target).toFile();
         saveMetaData(metaDataFile, cacheFile.length(), uncompressedSize, lastChanged, md);
     }
 
@@ -425,8 +428,7 @@ public class CveCommand extends AbstractNvdCommand {
     private void saveRecentlyModifiedCacheFile(List<DefCveItem> recentlyChanged, CacheProperties properties,
             ZonedDateTime lastChanged) {
         properties.set("lastModifiedDate.modified", lastChanged);
-        final String prefix = properties.get("prefix", "nvdcve-");
-        Path recentChangesCachePath = Path.of(properties.getDirectory().getPath(), prefix + "modified.json.gz");
+        Path recentChangesCachePath = buildCacheTargetFile(properties, "modified");
 
         // preload the old modified
         CvesNvdPojo oldModifiedCacheData = loadCvesFromCache(recentChangesCachePath);
@@ -440,21 +442,9 @@ public class CveCommand extends AbstractNvdCommand {
         }
         // ensure we do not include a slice more than 8 days old
         removeOutdatedCves(vulnerabilities);
-        vulnerabilities.sort(Comparator.comparing(v -> v.getCve().getId()));
-        int recentSize = vulnerabilities.size();
-        CveApiJson20 data = new CveApiJson20(recentSize, 0, recentSize, FORMAT, VERSION, lastChanged, vulnerabilities);
 
-        MessageDigest md = getDigestAlg();
-
-        // create cache file including the CVE entries that recently changed
-        File recentCacheFile = recentChangesCachePath.toFile();
-        long uncompressedSize = saveCvesToCache(recentCacheFile, data, md);
-        LOG.info("INFO Stored {} entries in {} as recent changed items across all years",
-                data.getVulnerabilities().size(), recentCacheFile.getName());
-
-        // Create meta-file
-        Path metaDataFile = Path.of(properties.getDirectory().getPath(), prefix + "modified.meta");
-        saveMetaData(metaDataFile.toFile(), recentCacheFile.length(), uncompressedSize, lastChanged, md);
+        CvesNvdPojo data = new CvesNvdPojo(vulnerabilities, lastChanged);
+        storeToCache("modified", data, properties);
     }
 
     private CvesNvdPojo loadCvesFromCache(Path cacheFilePath) {
@@ -525,14 +515,14 @@ public class CveCommand extends AbstractNvdCommand {
                 ZoneOffset.UTC);
     }
 
-    private Path buildCacheTargetFileForYear(CacheProperties properties, int year) {
+    private Path buildCacheTargetFile(CacheProperties properties, String target) {
         final String prefix = properties.get("prefix", "nvdcve-");
-        return Path.of(properties.getDirectory().getPath(), prefix + year + ".json.gz");
+        return Path.of(properties.getDirectory().getPath(), prefix + target + ".json.gz");
     }
 
-    private Path buildMetaDataTargetFileForYear(CacheProperties properties, int year) {
+    private Path buildMetaDataTargetFile(CacheProperties properties, String target) {
         final String prefix = properties.get("prefix", "nvdcve-");
-        return Path.of(properties.getDirectory().getPath(), prefix + year + ".meta");
+        return Path.of(properties.getDirectory().getPath(), prefix + target + ".meta");
     }
 
     /**

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/CveCommand.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/CveCommand.java
@@ -385,7 +385,8 @@ public class CveCommand extends AbstractNvdCommand {
             CvesNvdPojo currentResult = fetchFromNVDApi(apiBuilder);
 
             // update our last updated, since we crawl up the year, this will be the most recent in the end
-            if (finalResult.lastUpdated == null || (currentResult.lastUpdated != null && finalResult.lastUpdated.isBefore(currentResult.lastUpdated))) {
+            if (finalResult.lastUpdated == null || (currentResult.lastUpdated != null
+                    && finalResult.lastUpdated.isBefore(currentResult.lastUpdated))) {
                 finalResult.lastUpdated = currentResult.lastUpdated;
             }
             // aggregate all results


### PR DESCRIPTION
- ensure the correct `lastUpdated` is captured per year
- cleanup code duplication
- ensure CVE-1988 - CVE-2001 are stored in year 2002