### PR TITLE
feat: implement forced http caching on full mirror of NVD

### DIFF
--- a/vulnz/build.gradle
+++ b/vulnz/build.gradle
@@ -8,15 +8,15 @@ plugins {
 
 description = 'A java CLI to call the NVD API'
 
-ext['httpclient5.version'] = '5.3.1'
-ext['httpcore5.version'] = '5.2.4'
-ext['httpcore5-h2.version'] = '5.2.4'
+ext['httpclient5.version'] = '5.4.2'
+ext['httpcore5.version'] = '5.3.3'
+ext['httpcore5-h2.version'] = '5.3.3'
 ext['snakeyaml.version'] = '2.2'
 ext['jackson.version'] = '2.17.1'
 ext['commons-lang3.version'] = '3.14.0'
 
 dependencies {
-    implementation 'io.github.jeremylong:open-vulnerability-clients:7.2.2'
+    implementation 'io.github.jeremylong:open-vulnerability-clients:7.3.0'
     implementation 'info.picocli:picocli-spring-boot-starter:4.7.6'
     constraints {
         implementation 'org.springframework.boot:spring-boot-starter:2.7.18'
@@ -37,6 +37,11 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
 jar {
     enabled = false
 }

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/cache/CacheProperties.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/cache/CacheProperties.java
@@ -30,7 +30,8 @@ import java.util.Properties;
 
 public class CacheProperties {
     private static final String NAME = "cache.properties";
-    public static final String IS_NEW = "is.new";
+    public static final String IS_NEW = "cache.is.new";
+    public static final String USING_EXISTING_CACHE = "cache.used.existing";
     Properties properties = new Properties();
     private File directory;
 
@@ -92,6 +93,12 @@ public class CacheProperties {
             properties.store(output, null);
         } catch (IOException exception) {
             throw new CacheException("Unable to write properties file: " + directory, exception);
+        }
+    }
+
+    public void remove(String key) {
+        if (properties.containsKey(key)) {
+            properties.remove(key);
         }
     }
 }

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/cache/CacheProperties.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/cache/CacheProperties.java
@@ -30,6 +30,7 @@ import java.util.Properties;
 
 public class CacheProperties {
     private static final String NAME = "cache.properties";
+    public static final String IS_NEW = "is.new";
     Properties properties = new Properties();
     private File directory;
 
@@ -46,6 +47,8 @@ public class CacheProperties {
             } catch (IOException exception) {
                 throw new CacheException("Unable to create read properties file: " + directory, exception);
             }
+        } else {
+            properties.setProperty(IS_NEW, "true");
         }
     }
 

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/cache/CacheUpdateException.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/cache/CacheUpdateException.java
@@ -1,0 +1,28 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023-2025 Jeremy Long. All Rights Reserved.
+ */
+package io.github.jeremylong.vulnz.cli.cache;
+
+public class CacheUpdateException extends Exception {
+
+    public CacheUpdateException(String msg) {
+        super(msg);
+    }
+
+    public CacheUpdateException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/CveCommand.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/CveCommand.java
@@ -31,6 +31,7 @@ import io.github.jeremylong.openvulnerability.client.nvd.NvdCveClient;
 import io.github.jeremylong.openvulnerability.client.nvd.NvdCveClientBuilder;
 import io.github.jeremylong.vulnz.cli.cache.CacheException;
 import io.github.jeremylong.vulnz.cli.cache.CacheProperties;
+import io.github.jeremylong.vulnz.cli.cache.CacheUpdateException;
 import io.github.jeremylong.vulnz.cli.model.BasicOutput;
 import io.github.jeremylong.vulnz.cli.ui.IProgressMonitor;
 import io.github.jeremylong.vulnz.cli.ui.JlineShutdownHook;
@@ -38,6 +39,7 @@ import io.github.jeremylong.vulnz.cli.ui.ProgressMonitor;
 import io.prometheus.metrics.core.metrics.Gauge;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.output.CountingOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,9 +62,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -137,6 +137,7 @@ public class CveCommand extends AbstractNvdCommand {
         if (isDebug()) {
             LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
             loggerContext.getLogger("io.github.jeremylong").setLevel(Level.DEBUG);
+            // loggerContext.getLogger("org.apache.hc.client5").setLevel(Level.DEBUG);
         }
         String apiKey = getApiKey();
         if (apiKey == null || apiKey.isEmpty()) {
@@ -243,9 +244,11 @@ public class CveCommand extends AbstractNvdCommand {
                 properties.set("prefix", configGroup.cacheSettings.prefix);
             }
             try {
-                int status = processRequest(builder, properties);
-                properties.save();
-                return status;
+                int exitCode = processMirrorRequest(builder, properties);
+                if (exitCode == 0 /* success */) {
+                    cleanUpAndSaveProperties(properties);
+                }
+                return exitCode;
             } catch (CacheException ex) {
                 LOG.error(ex.getMessage(), ex);
             }
@@ -262,7 +265,26 @@ public class CveCommand extends AbstractNvdCommand {
         return processRequest(builder);
     }
 
-    private Integer processRequest(NvdCveClientBuilder builder, CacheProperties properties) {
+    /**
+     * Deletes the HTTP Cache Directory if it exists and is no longer needed, and saves the cache properties.
+     * @param properties the cache properties to save
+     */
+    private void cleanUpAndSaveProperties(CacheProperties properties) {
+        if (Boolean.parseBoolean(properties.get(CacheProperties.IS_NEW, "false"))) {
+            File cacheDir = getCacheDirectory();
+            if (cacheDir.exists() && cacheDir.isDirectory()) {
+                try {
+                    FileUtils.deleteDirectory(cacheDir);
+                } catch (IOException ex) {
+                    LOG.error("Unable to delete the HTTP Cache Directory `{}`, error: {}", cacheDir.getAbsoluteFile(), ex.getMessage());
+                }
+            }
+        }
+        properties.set(CacheProperties.IS_NEW, "false");
+        properties.save();
+    }
+
+    private Integer processMirrorRequest(NvdCveClientBuilder builder, CacheProperties properties) {
         final ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());
         if (isPrettyPrint()) {
@@ -271,7 +293,15 @@ public class CveCommand extends AbstractNvdCommand {
         final Object2ObjectOpenHashMap<String, Object2ObjectOpenHashMap<String, DefCveItem>> cves = new Object2ObjectOpenHashMap<>();
         populateKeys(cves);
 
-        ZonedDateTime lastModified = downloadAllUpdates(builder, cves);
+        determineHttpCachingStrategy(builder, properties);
+
+        ZonedDateTime lastModified = null;
+        try {
+            lastModified = downloadAllUpdates(builder, cves);
+        } catch (CacheUpdateException e) {
+            LOG.error("NVD Cache Update Failed", e);
+            return 100;
+        }
         if (lastModified != null) {
             properties.set("lastModifiedDate", lastModified);
         }
@@ -357,6 +387,20 @@ public class CveCommand extends AbstractNvdCommand {
         return 0;
     }
 
+    private static void determineHttpCachingStrategy(NvdCveClientBuilder builder, CacheProperties properties) {
+        if (Boolean.parseBoolean(properties.get(CacheProperties.IS_NEW, "false"))) {
+            final File httpCacheDir = getHttpCacheDir(properties);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Using http cache directory {}", httpCacheDir);
+            }
+            builder.withCacheDirectory(httpCacheDir.toPath());
+        }
+    }
+
+    private static File getHttpCacheDir(CacheProperties properties) {
+        return new File(properties.getDirectory(), ".nvd_requests");
+    }
+
     private static void populateKeys(
             Object2ObjectOpenHashMap<String, Object2ObjectOpenHashMap<String, DefCveItem>> cves) {
         cves.put("modified", new Object2ObjectOpenHashMap<>());
@@ -366,7 +410,7 @@ public class CveCommand extends AbstractNvdCommand {
     }
 
     private ZonedDateTime downloadAllUpdates(NvdCveClientBuilder builder,
-            Object2ObjectOpenHashMap<String, Object2ObjectOpenHashMap<String, DefCveItem>> cves) {
+            Object2ObjectOpenHashMap<String, Object2ObjectOpenHashMap<String, DefCveItem>> cves) throws CacheUpdateException {
         ZonedDateTime lastModified = null;
         int count = 0;
         // retrieve from NVD API
@@ -382,7 +426,7 @@ public class CveCommand extends AbstractNvdCommand {
             }
         } catch (Exception ex) {
             LOG.debug("\nERROR", ex);
-            throw new CacheException("Unable to complete NVD cache update due to error: " + ex.getMessage());
+            throw new CacheUpdateException("Unable to complete NVD cache update due to error: " + ex.getMessage());
         }
         CVE_COUNTER.set(cves.values().stream().mapToLong(Object2ObjectOpenHashMap::size).sum());
         return lastModified;

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/CveCommand.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/CveCommand.java
@@ -57,10 +57,12 @@ import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Year;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -144,6 +146,69 @@ public class CveCommand extends AbstractNvdCommand {
             LOG.info("NVD_API_KEY not found. Supply an API key for more generous rate limits");
             apiKey = null;// in case it is empty
         }
+        NvdCveClientBuilder builder = getNvdCveClientBuilder(apiKey);
+
+        if (configGroup != null && configGroup.cacheSettings != null) {
+            CacheProperties properties = new CacheProperties(configGroup.cacheSettings.directory);
+            checkIfHttpCacheExists(properties);
+            if (properties.has("lastModifiedDate")) {
+                ZonedDateTime start = properties.getTimestamp("lastModifiedDate");
+                ZonedDateTime end = start.minusDays(-120);
+                if (end.compareTo(ZonedDateTime.now()) > 0) {
+                    builder.withLastModifiedFilter(start, end);
+                } else {
+                    LOG.warn(
+                            "Requesting the entire set of NVD CVE data via the api as the cache was last updated over 120 days ago");
+                }
+            }
+            if (configGroup.cacheSettings.prefix != null) {
+                properties.set("prefix", configGroup.cacheSettings.prefix);
+            }
+            try {
+                int exitCode = processMirrorRequest(builder, properties);
+                if (exitCode == 0 /* success */) {
+                    boolean usedExistingCache = Boolean
+                            .parseBoolean(properties.get(CacheProperties.USING_EXISTING_CACHE, "false"));
+                    performCleanup(properties);
+                    properties.save();
+                    if (usedExistingCache) {
+                        exitCode = updateMirrorWithLast24Hours(apiKey, properties);
+                    }
+                }
+                return exitCode;
+            } catch (CacheException ex) {
+                LOG.error(ex.getMessage(), ex);
+            }
+            return 1;
+        }
+        if (configGroup != null && configGroup.modifiedRange != null
+                && configGroup.modifiedRange.lastModStartDate != null) {
+            ZonedDateTime end = configGroup.modifiedRange.lastModEndDate;
+            if (end == null) {
+                end = configGroup.modifiedRange.lastModStartDate.minusDays(-120);
+            }
+            builder.withLastModifiedFilter(configGroup.modifiedRange.lastModStartDate, end);
+        }
+        return processRequest(builder);
+    }
+
+    private int updateMirrorWithLast24Hours(String apiKey, CacheProperties properties) {
+        NvdCveClientBuilder builder;
+        int exitCode;
+        LOG.info(
+                "Used previously cached HTTP Responses from the NVD; running the update again to obtain entries modified in the last 24 hours");
+        builder = getNvdCveClientBuilder(apiKey);
+        ZonedDateTime start = ZonedDateTime.now(ZoneOffset.UTC).minusHours(24);
+        ZonedDateTime end = start.minusDays(-120);
+        builder.withLastModifiedFilter(start, end);
+        exitCode = processMirrorRequest(builder, properties);
+        if (exitCode == 0) {
+            properties.save();
+        }
+        return exitCode;
+    }
+
+    private NvdCveClientBuilder getNvdCveClientBuilder(String apiKey) {
         NvdCveClientBuilder builder = NvdCveClientBuilder.aNvdCveApi().withApiKey(apiKey);
         if (getDelay() > 0) {
             builder.withDelay(getDelay());
@@ -227,61 +292,40 @@ public class CveCommand extends AbstractNvdCommand {
         if (getThreads() > 0) {
             builder.withThreadCount(getThreads());
         }
+        return builder;
+    }
 
-        if (configGroup != null && configGroup.cacheSettings != null) {
-            CacheProperties properties = new CacheProperties(configGroup.cacheSettings.directory);
-            if (properties.has("lastModifiedDate")) {
-                ZonedDateTime start = properties.getTimestamp("lastModifiedDate");
-                ZonedDateTime end = start.minusDays(-120);
-                if (end.compareTo(ZonedDateTime.now()) > 0) {
-                    builder.withLastModifiedFilter(start, end);
-                } else {
-                    LOG.warn(
-                            "Requesting the entire set of NVD CVE data via the api as the cache was last updated over 120 days ago");
+    private void checkIfHttpCacheExists(CacheProperties properties) {
+        if (Boolean.parseBoolean(properties.get(CacheProperties.IS_NEW, "false"))) {
+            File cacheDir = getCacheDirectory();
+            if (cacheDir != null && cacheDir.exists() && cacheDir.isDirectory()) {
+                File[] files = cacheDir.listFiles();
+                if (files != null && files.length > 0 && Arrays.stream(files)
+                        .anyMatch(file -> file.lastModified() >= System.currentTimeMillis() - 72000000)) {
+                    properties.set(CacheProperties.USING_EXISTING_CACHE, "true");
                 }
             }
-            if (configGroup.cacheSettings.prefix != null) {
-                properties.set("prefix", configGroup.cacheSettings.prefix);
-            }
-            try {
-                int exitCode = processMirrorRequest(builder, properties);
-                if (exitCode == 0 /* success */) {
-                    cleanUpAndSaveProperties(properties);
-                }
-                return exitCode;
-            } catch (CacheException ex) {
-                LOG.error(ex.getMessage(), ex);
-            }
-            return 1;
         }
-        if (configGroup != null && configGroup.modifiedRange != null
-                && configGroup.modifiedRange.lastModStartDate != null) {
-            ZonedDateTime end = configGroup.modifiedRange.lastModEndDate;
-            if (end == null) {
-                end = configGroup.modifiedRange.lastModStartDate.minusDays(-120);
-            }
-            builder.withLastModifiedFilter(configGroup.modifiedRange.lastModStartDate, end);
-        }
-        return processRequest(builder);
     }
 
     /**
      * Deletes the HTTP Cache Directory if it exists and is no longer needed, and saves the cache properties.
      * @param properties the cache properties to save
      */
-    private void cleanUpAndSaveProperties(CacheProperties properties) {
+    private void performCleanup(CacheProperties properties) {
         if (Boolean.parseBoolean(properties.get(CacheProperties.IS_NEW, "false"))) {
-            File cacheDir = getCacheDirectory();
+            File cacheDir = getHttpCacheDir(properties);
             if (cacheDir.exists() && cacheDir.isDirectory()) {
                 try {
                     FileUtils.deleteDirectory(cacheDir);
                 } catch (IOException ex) {
-                    LOG.error("Unable to delete the HTTP Cache Directory `{}`, error: {}", cacheDir.getAbsoluteFile(), ex.getMessage());
+                    LOG.error("Unable to delete the HTTP Cache Directory `{}`, error: {}", cacheDir.getAbsoluteFile(),
+                            ex.getMessage());
                 }
             }
         }
         properties.set(CacheProperties.IS_NEW, "false");
-        properties.save();
+        properties.remove(CacheProperties.USING_EXISTING_CACHE);
     }
 
     private Integer processMirrorRequest(NvdCveClientBuilder builder, CacheProperties properties) {
@@ -410,7 +454,8 @@ public class CveCommand extends AbstractNvdCommand {
     }
 
     private ZonedDateTime downloadAllUpdates(NvdCveClientBuilder builder,
-            Object2ObjectOpenHashMap<String, Object2ObjectOpenHashMap<String, DefCveItem>> cves) throws CacheUpdateException {
+            Object2ObjectOpenHashMap<String, Object2ObjectOpenHashMap<String, DefCveItem>> cves)
+            throws CacheUpdateException {
         ZonedDateTime lastModified = null;
         int count = 0;
         // retrieve from NVD API

--- a/vulnz/src/main/resources/logback-spring.xml
+++ b/vulnz/src/main/resources/logback-spring.xml
@@ -1,11 +1,4 @@
 <configuration>
-
-<!--    <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">-->
-<!--        <target>System.err</target>-->
-<!--        <layout class="ch.qos.logback.classic.PatternLayout">-->
-<!--            <Pattern>%msg%n%throwable</Pattern>-->
-<!--        </layout>-->
-<!--    </appender>-->
     <appender name="STDERR" class="io.github.jeremylong.vulnz.cli.ui.JLineAppender">
         <layout class="ch.qos.logback.classic.PatternLayout">
             <Pattern>%msg%n%throwable</Pattern>
@@ -16,5 +9,4 @@
     </root>
     <logger name="org.hibernate" level="ERROR" />
     <logger name="SQL dialect" level="OFF" />
-
 </configuration>


### PR DESCRIPTION
If performing a full download of the NVD data for purposes of creating a local mirror - enable forced, persistent HTTP Caching of the responses from the NVD API.

1. Only enable caching when creating a full mirror.
2. Delete any existing HTTP cached files if the full update is successful.
3. Set a status code of 100 so we can watch for this and kick off the download again.

This is a draft PR as it is pending the release of https://github.com/jeremylong/open-vulnerability-clients/pull/4.
