### PR TITLE
fix: Issue a warning when users have used an un-resolved user-home relative path

### DIFF
--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/services/NvdMirrorService.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/services/NvdMirrorService.java
@@ -82,6 +82,10 @@ public class NvdMirrorService {
 
     public NvdMirrorService(File propertyFile, String prefix, NvdCveClientBuilder nvdCveClientBuilder,
             boolean interactive) {
+        if (propertyFile.toString().startsWith("~")) {
+            LOG.warn(
+                    "Cache directory is starting with '~', did you intend to target a folder within a user home folder? Then separate the --directory option and location by space instead of equals-sign ( --directory ~/__path__ ) so that shell-expansion resolves the proper location.");
+        }
         this.properties = new CacheProperties(propertyFile);
         if (prefix != null) {
             properties.set("prefix", prefix);


### PR DESCRIPTION
Fixes issue #293 by warning the user that they likely used the wrong command-line syntax for the `--directory` option (unless they truly wished to cache underneath a `~`-folder.

```
aikebah@rajah open-vulnerability-cli % java -jar vulnz/build/libs/vulnz-8.0.1-local.jar cve --directory=~/.vulnz-mirror --cache --threads=4
                           _/
 _/      _/   _/    _/    _/     _/_/_/     _/_/_/_/
_/      _/   _/    _/    _/     _/    _/       _/
 _/  _/     _/    _/    _/     _/    _/     _/
  _/         _/_/_/    _/     _/    _/   _/_/_/_/

Version: 8.0.1-local

Open Vulnerability Project
💖 Sponsor: https://github.com/sponsors/jeremylong




NVD_API_KEY not found. Supply an API key for more generous rate limits

Cache directory is starting with '~', did you intend to target a user home directory? Then separate the --directory option and location by space instead of equals-sign ( --directory ~/__path__ ) so that shell-expansion resolves the proper location.

```