### PR TITLE
Fix the problem #309 Add support for custom CA certificates in scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ There are a couple of ENV vars
 - `METRICS_ENABLE` If is set to `true`, OpenMetrics data for the vulnz cli can be retrieved via the endpoint http://.../metrics
 - `METRICS_WRITE_INTERVAL` Sets the update interval for generating metrics, in milliseconds. Default: `5000`
 - `METRICS_WRITER_FORMAT` Sets the output format for the metrics. Either `openmetrics` or `prometheus` format. Default: `openmetrics`
+- `CACERT` Path to a custom Certificate Authority (CA) certificate file that should be used for secure SSL/TLS connections with curl. Example: `/cacert.pem`
+
 
 ### Run
 
@@ -143,6 +145,10 @@ docker run --name vulnz -e JAVA_OPT=-Xmx2g jeremylong/open-vulnerability-data-mi
 
 # you can also adjust the delay 
 docker run --name vulnz -e NVD_API_KEY=myapikey -e DELAY=3000 jeremylong/open-vulnerability-data-mirror:v8.1.1 
+
+# mounts the custom Java `cacerts` file from your local machine into the container for secure SSL/TLS connections with java
+# and mounts the custom `cafile` from your local machine into the container for secure SSL/TLS connections with curl
+docker run --name vulnz -v /path/to/java/cacerts:/etc/ssl/certs/java/cacerts -v /path/to/cacert.pem:/cacert.pem jeremylong/open-vulnerability-data-mirror:v8.1.1
 ```
 
 If you like, run this to pre-populate the mirror right away

--- a/vulnz/src/docker/scripts/epss.sh
+++ b/vulnz/src/docker/scripts/epss.sh
@@ -18,7 +18,18 @@ function remove_lockfile() {
 }
 trap remove_lockfile SIGHUP SIGINT SIGQUIT SIGABRT SIGALRM SIGTERM SIGTSTP
 
-curl -L -sS -o /usr/local/apache2/htdocs/epss_scores-current.csv.gz https://epss.cyentia.com/epss_scores-current.csv.gz
+CACERT_ARG=""
+if [ -n "${CACERT}" ]; then
+  echo "Using cacert file: $CACERT"
+  if [ -f "$CACERT" ]; then
+    echo "File $CACERT exists."
+    CACERT_ARG="--cacert $CACERT"
+  else
+    echo "File $CACERT not found."
+  fi
+fi
+
+curl -L -sS $CACERT_ARG -o /usr/local/apache2/htdocs/epss_scores-current.csv.gz https://epss.cyentia.com/epss_scores-current.csv.gz
 
 if [ -f /usr/local/apache2/htdocs/epss_scores-current.csv.gz ]; then
   timestamp=$(stat -c "%Y" "/usr/local/apache2/htdocs/epss_scores-current.csv.gz" | xargs -I{} date -d @{} "+%Y-%m-%d %H:%M:%S")

--- a/vulnz/src/docker/scripts/kev.sh
+++ b/vulnz/src/docker/scripts/kev.sh
@@ -18,7 +18,18 @@ function remove_lockfile() {
 }
 trap remove_lockfile SIGHUP SIGINT SIGQUIT SIGABRT SIGALRM SIGTERM SIGTSTP
 
-curl -L -sS -o /usr/local/apache2/htdocs/known_exploited_vulnerabilities.json https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json
+CACERT_ARG=""
+if [ -n "${CACERT}" ]; then
+  echo "Using cacert file: $CACERT"
+  if [ -f "$CACERT" ]; then
+    echo "File $CACERT exists."
+    CACERT_ARG="--cacert $CACERT"
+  else
+    echo "File $CACERT not found."
+  fi
+fi
+
+curl -L -sS $CACERT_ARG -o /usr/local/apache2/htdocs/known_exploited_vulnerabilities.json https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json
 
 if [ -f /usr/local/apache2/htdocs/known_exploited_vulnerabilities.json ]; then
   timestamp=$(stat -c "%Y" "/usr/local/apache2/htdocs/known_exploited_vulnerabilities.json" | xargs -I{} date -d @{} "+%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
Introduce the `CACERT` option for specifying a custom CA certificate file to enhance secure SSL/TLS connections in `kev.sh` and `epss.sh` scripts. Updated `README.md` to document the usage and provide Docker run examples leveraging custom certificates.