### PR TITLE
feat!: CveCommand replaces --threads argument with --requestCount

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ the `op` CLI (see [getting started with op](https://developer.1password.com/docs
 ```bash
 export NVD_API_KEY=op://vaultname/nvd-api/credential
 eval $(op signin)
-op run -- vulnz cve --threads 4 > cve-complete.json
+op run -- vulnz cve --requestCount 40 > cve-complete.json
 ```
 
 ## Mirroring the NVD CVE Data

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version = 8.1.1
+version = 9.0.0

--- a/vulnz/build.gradle
+++ b/vulnz/build.gradle
@@ -16,7 +16,7 @@ ext['jackson.version'] = '2.17.1'
 ext['commons-lang3.version'] = '3.17.0'
 
 dependencies {
-    implementation 'io.github.jeremylong:open-vulnerability-clients:7.3.2'
+    implementation 'io.github.jeremylong:open-vulnerability-clients:8.0.0'
     implementation 'info.picocli:picocli-spring-boot-starter:4.7.7'
     constraints {
         implementation 'org.springframework.boot:spring-boot-starter:3.4.2'

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/AbstractNvdCommand.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/AbstractNvdCommand.java
@@ -57,9 +57,9 @@ public abstract class AbstractNvdCommand extends AbstractJsonCommand {
     }
 
     /**
-     * Returns the number of request to make over a 30-second window.
+     * Returns the number of requests to make over a 30-second window.
      *
-     * @return the number of request to make over a 30-second window
+     * @return the number of requests to make over a 30-second window
      */
     protected int getRequestPer30Seconds() {
         return requestsPer30Seconds;

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/AbstractNvdCommand.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/AbstractNvdCommand.java
@@ -38,10 +38,11 @@ public abstract class AbstractNvdCommand extends AbstractJsonCommand {
             "--pageCount"}, description = "The number of `pages` of data to retrieve from the NVD if more then a single page is returned")
     private int pageCount = 0;
     @CommandLine.Option(names = {
+            "--requestCount"}, description = "The number of requests to make to the NVD API in a 30-second rolling window")
+    private int requestsPer30Seconds = 0;
+    @CommandLine.Option(names = {
             "--recordsPerPage"}, description = "The number of records per pages of data to retrieve from the NVD in a single call")
     private int recordsPerPage = 2000;
-    @CommandLine.Option(names = {"--threads"}, description = "The number of threads to use when calling the NVd API")
-    private int threads = 1;
     // yes - this should not be a string, but seriously down the call path the HttpClient
     // doesn't support passing a header in as a char[]...
     private String apiKey = null;
@@ -56,12 +57,12 @@ public abstract class AbstractNvdCommand extends AbstractJsonCommand {
     }
 
     /**
-     * Returns the number of threads to use when calling the NVD API.
+     * Returns the number of request to make over a 30-second window.
      *
-     * @return the number of threads to use when calling the NVD API
+     * @return the number of request to make over a 30-second window
      */
-    protected int getThreads() {
-        return threads;
+    protected int getRequestPer30Seconds() {
+        return requestsPer30Seconds;
     }
 
     /**

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/CveCommand.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/CveCommand.java
@@ -88,6 +88,8 @@ public class CveCommand extends AbstractNvdCommand {
         if (apiKey == null || apiKey.isEmpty()) {
             LOG.info("NVD_API_KEY not found. Supply an API key for more generous rate limits");
             apiKey = null;// in case it is empty
+        } else {
+            LOG.debug("NVD_API_KEY is being used");
         }
         NvdCveClientBuilder builder = getNvdCveClientBuilder(apiKey);
 
@@ -201,8 +203,8 @@ public class CveCommand extends AbstractNvdCommand {
         if (getPageCount() > 0) {
             builder.withMaxPageCount(getPageCount());
         }
-        if (getThreads() > 0) {
-            builder.withThreadCount(getThreads());
+        if (getRequestPer30Seconds() > 0) {
+            builder.withrequestsPerThirtySeconds(getRequestPer30Seconds());
         }
         return builder;
     }


### PR DESCRIPTION
BREAKING CHANGE:
- feat: The new argument for CveCommand `--requestCount` is the number of requests allowed over a 30-second rolling window. The `--threads` argument was removed.
- build(deps): bump `io.github.jeremylong:open-vulnerability-clients` from 7.3.2 to 8.0.0
  -  See release notes: https://github.com/jeremylong/open-vulnerability-clients/releases/tag/v8.0.0
