### PR TITLE
feat!: CveCommand replaces --threads argument with --requestCount 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ After running `install` you may need to restart your shell for the completion to
 ```bash
 ./gradlew vulnz:build
 cd vulnz/build/libs
-./vulnz-8.1.1.jar install
+./vulnz-9.0.0.jar install
 vulnz cve --cveId CVE-2021-44228 --prettyPrint
 ```
 
@@ -87,7 +87,7 @@ export JAVA_OPTS="-Xmx2g"
 Alternatively, run the CLI using the `-Xmx2g` argument:
 
 ```bash
-java -Xmx2g -jar ./vulnz-8.1.1.jar
+java -Xmx2g -jar ./vulnz-9.0.0.jar
 ```
 
 An option to save memory would be: `-XX:+UseStringDeduplication`:
@@ -107,7 +107,7 @@ vulnz cve --cache --directory ./cache
 Alternatively, without using the above install command:
 
 ```bash
-./vulnz-8.1.1.jar cve --cache --directory ./cache
+./vulnz-9.0.0.jar cve --cache --directory ./cache
 ```
 
 When creating the cache all other arguments to the vulnz cli
@@ -135,20 +135,20 @@ There are a couple of ENV vars
 
 ```bash
 # replace the NVD_API_KEY with your NVD api key
-docker run --name vulnz -e NVD_API_KEY=myapikey jeremylong/open-vulnerability-data-mirror:v8.1.1 
+docker run --name vulnz -e NVD_API_KEY=myapikey jeremylong/open-vulnerability-data-mirror:v9.0.0 
 
 # if you like use a volume 
-docker run --name vulnz -e NVD_API_KEY=myapikey -v cache:/usr/local/apache2/htdocs jeremylong/open-vulnerability-data-mirror:v8.1.1
+docker run --name vulnz -e NVD_API_KEY=myapikey -v cache:/usr/local/apache2/htdocs jeremylong/open-vulnerability-data-mirror:v9.0.0
 
 # adjust the memory usage
-docker run --name vulnz -e JAVA_OPT=-Xmx2g jeremylong/open-vulnerability-data-mirror:v8.1.1
+docker run --name vulnz -e JAVA_OPT=-Xmx2g jeremylong/open-vulnerability-data-mirror:v9.0.0
 
 # you can also adjust the delay 
-docker run --name vulnz -e NVD_API_KEY=myapikey -e DELAY=3000 jeremylong/open-vulnerability-data-mirror:v8.1.1 
+docker run --name vulnz -e NVD_API_KEY=myapikey -e DELAY=3000 jeremylong/open-vulnerability-data-mirror:v9.0.0 
 
 # mounts the custom Java `cacerts` file from your local machine into the container for secure SSL/TLS connections with java
 # and mounts the custom `cafile` from your local machine into the container for secure SSL/TLS connections with curl
-docker run --name vulnz -v /path/to/java/cacerts:/etc/ssl/certs/java/cacerts -v /path/to/cacert.pem:/cacert.pem jeremylong/open-vulnerability-data-mirror:v8.1.1
+docker run --name vulnz -v /path/to/java/cacerts:/etc/ssl/certs/java/cacerts -v /path/to/cacert.pem:/cacert.pem jeremylong/open-vulnerability-data-mirror:v9.0.0
 ```
 
 If you like, run this to pre-populate the mirror right away
@@ -159,10 +159,10 @@ docker exec -u mirror vulnz /mirror.sh
 
 ### Build
 
-Assuming the current version is `8.1.1`
+Assuming the current version is `9.0.0`
 
 ```bash
-export TARGET_VERSION=8.1.1
+export TARGET_VERSION=9.0.0
 ./gradlew vulnz:build -Pversion=$TARGET_VERSION
 docker build vulnz/ -t ghcr.io/jeremylong/vulnz:$TARGET_VERSION --build-arg BUILD_VERSION=$TARGET_VERSION
 ```
@@ -171,7 +171,7 @@ docker build vulnz/ -t ghcr.io/jeremylong/vulnz:$TARGET_VERSION --build-arg BUIL
 
 ```bash
 # checkout the repo
-git tag -a 'v8.1.1'' -m 'release 8.1.1'
+git tag -a 'v9.0.0'' -m 'release 9.0.0'
 git push --tags
-# this will build vulnz 8.1.1 on publish the docker image tagged 8.1.1 
+# this will build vulnz 9.0.0 on publish the docker image tagged 9.0.0 
 ```

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ the `op` CLI (see [getting started with op](https://developer.1password.com/docs
 ```bash
 export NVD_API_KEY=op://vaultname/nvd-api/credential
 eval $(op signin)
-op run -- vulnz cve --threads 4 > cve-complete.json
+op run -- vulnz cve --requestCount 40 > cve-complete.json
 ```
 
 ## Mirroring the NVD CVE Data

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version = 8.1.1
+version = 9.0.0

--- a/vulnz/build.gradle
+++ b/vulnz/build.gradle
@@ -16,7 +16,7 @@ ext['jackson.version'] = '2.17.1'
 ext['commons-lang3.version'] = '3.17.0'
 
 dependencies {
-    implementation 'io.github.jeremylong:open-vulnerability-clients:7.3.2'
+    implementation 'io.github.jeremylong:open-vulnerability-clients:8.0.0'
     implementation 'info.picocli:picocli-spring-boot-starter:4.7.7'
     constraints {
         implementation 'org.springframework.boot:spring-boot-starter:3.4.2'

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/AbstractNvdCommand.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/AbstractNvdCommand.java
@@ -57,9 +57,9 @@ public abstract class AbstractNvdCommand extends AbstractJsonCommand {
     }
 
     /**
-     * Returns the number of request to make over a 30-second window.
+     * Returns the number of requests to make over a 30-second window.
      *
-     * @return the number of request to make over a 30-second window
+     * @return the number of requests to make over a 30-second window
      */
     protected int getRequestPer30Seconds() {
         return requestsPer30Seconds;

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/AbstractNvdCommand.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/AbstractNvdCommand.java
@@ -38,10 +38,11 @@ public abstract class AbstractNvdCommand extends AbstractJsonCommand {
             "--pageCount"}, description = "The number of `pages` of data to retrieve from the NVD if more then a single page is returned")
     private int pageCount = 0;
     @CommandLine.Option(names = {
+            "--requestCount"}, description = "The number of requests to make to the NVD API in a 30-second rolling window")
+    private int requestsPer30Seconds = 0;
+    @CommandLine.Option(names = {
             "--recordsPerPage"}, description = "The number of records per pages of data to retrieve from the NVD in a single call")
     private int recordsPerPage = 2000;
-    @CommandLine.Option(names = {"--threads"}, description = "The number of threads to use when calling the NVd API")
-    private int threads = 1;
     // yes - this should not be a string, but seriously down the call path the HttpClient
     // doesn't support passing a header in as a char[]...
     private String apiKey = null;
@@ -56,12 +57,12 @@ public abstract class AbstractNvdCommand extends AbstractJsonCommand {
     }
 
     /**
-     * Returns the number of threads to use when calling the NVD API.
+     * Returns the number of request to make over a 30-second window.
      *
-     * @return the number of threads to use when calling the NVD API
+     * @return the number of request to make over a 30-second window
      */
-    protected int getThreads() {
-        return threads;
+    protected int getRequestPer30Seconds() {
+        return requestsPer30Seconds;
     }
 
     /**

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/CveCommand.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/CveCommand.java
@@ -88,6 +88,8 @@ public class CveCommand extends AbstractNvdCommand {
         if (apiKey == null || apiKey.isEmpty()) {
             LOG.info("NVD_API_KEY not found. Supply an API key for more generous rate limits");
             apiKey = null;// in case it is empty
+        } else {
+            LOG.debug("NVD_API_KEY is being used");
         }
         NvdCveClientBuilder builder = getNvdCveClientBuilder(apiKey);
 
@@ -201,8 +203,8 @@ public class CveCommand extends AbstractNvdCommand {
         if (getPageCount() > 0) {
             builder.withMaxPageCount(getPageCount());
         }
-        if (getThreads() > 0) {
-            builder.withThreadCount(getThreads());
+        if (getRequestPer30Seconds() > 0) {
+            builder.withrequestsPerThirtySeconds(getRequestPer30Seconds());
         }
         return builder;
     }


### PR DESCRIPTION
BREAKING CHANGE:
- bump open-vulnerbility-clients from 7.3.2 to 8.0.0.
- remove `--threads` argument from the CVE Command as the client library no longer accepts the parameter.
- add `--requestCount` to CVE Command to specify the number of requests allowed over a rolling 30-second window.