### PR TITLE
fix: stream NVD mirror cache writes

### DIFF
--- a/src/main/java/io/github/jeremylong/vulnz/cli/monitoring/CveCounterPerYear.java
+++ b/src/main/java/io/github/jeremylong/vulnz/cli/monitoring/CveCounterPerYear.java
@@ -16,10 +16,10 @@
  */
 package io.github.jeremylong.vulnz.cli.monitoring;
 
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import io.github.jeremylong.openvulnerability.client.nvd.CveApiJson20;
 import io.github.jeremylong.openvulnerability.client.nvd.DefCveItem;
 import io.github.jeremylong.vulnz.cli.cache.CacheException;
 import io.prometheus.metrics.core.metrics.Gauge;
@@ -27,9 +27,12 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.zip.GZIPInputStream;
@@ -106,14 +109,56 @@ public class CveCounterPerYear {
         for (String year : cves.keySet()) {
             final File file = new File(directory, prefix + year + ".json.gz");
             if (file.isFile()) {
-                try (FileInputStream fis = new FileInputStream(file); GZIPInputStream gzis = new GZIPInputStream(fis)) {
-                    CveApiJson20 data = objectMapper.readValue(gzis, CveApiJson20.class);
-                    cveCountPerYear.put(year, data.getVulnerabilities().size());
+                try {
+                    Integer count = readCveCountFromMeta(year);
+                    if (count == null) {
+                        count = streamCveCount(file);
+                    }
+                    cveCountPerYear.put(year, count);
                 } catch (IOException exception) {
                     throw new CacheException("Unable to read cached data: " + file, exception);
                 }
             }
         }
+    }
+
+    private Integer readCveCountFromMeta(String year) throws IOException {
+        final File file = new File(directory, prefix + year + ".meta");
+        if (file.isFile()) {
+            try (BufferedReader reader = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    if (line.startsWith("cveCount:")) {
+                        try {
+                            return Integer.parseInt(line.substring("cveCount:".length()));
+                        } catch (NumberFormatException exception) {
+                            LOG.warn("Unable to parse cveCount from {}", file, exception);
+                            return null;
+                        }
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private int streamCveCount(File file) throws IOException {
+        int count = 0;
+        try (FileInputStream fis = new FileInputStream(file);
+                GZIPInputStream gzis = new GZIPInputStream(fis);
+                var parser = objectMapper.getFactory().createParser(gzis)) {
+            while (parser.nextToken() != null) {
+                if (parser.currentToken() != JsonToken.FIELD_NAME || !"vulnerabilities".equals(parser.currentName())) {
+                    continue;
+                }
+                parser.nextToken();
+                while (parser.nextToken() == JsonToken.START_OBJECT) {
+                    parser.skipChildren();
+                    count++;
+                }
+            }
+        }
+        return count;
     }
 
     /**
@@ -135,6 +180,9 @@ public class CveCounterPerYear {
      * @param cveCount the count of CVEs for the specified year
      */
     public void setCveCountPerYear(String year, int cveCount) {
+        if (cveCountPerYear == null) {
+            cveCountPerYear = new TreeMap<>();
+        }
         CVE_COUNTER_PER_YEAR.labelValues(year).set(cveCount);
         cveCountPerYear.put(year, cveCount);
         CVE_COUNTER.set(cveCountPerYear.entrySet().stream().filter(entry -> !MODIFIED.equalsIgnoreCase(entry.getKey()))

--- a/src/main/java/io/github/jeremylong/vulnz/cli/services/NvdMirrorService.java
+++ b/src/main/java/io/github/jeremylong/vulnz/cli/services/NvdMirrorService.java
@@ -19,7 +19,6 @@ package io.github.jeremylong.vulnz.cli.services;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.github.jeremylong.openvulnerability.client.nvd.CveApiJson20;
 import io.github.jeremylong.openvulnerability.client.nvd.DefCveItem;
 import io.github.jeremylong.openvulnerability.client.nvd.NvdCveClient;
 import io.github.jeremylong.openvulnerability.client.nvd.NvdCveClientBuilder;
@@ -46,6 +45,9 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -54,11 +56,12 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -276,65 +279,41 @@ public class NvdMirrorService {
         writeJsonMirror(cves, lastModified, 0);
     }
 
-    @SuppressFBWarnings(value = "DM_GC", justification = "Without calling System.gc() the JVM uses 2+GB of memory, calling gc profiling results in less than 1GB")
-    private void writeJsonMirror(Object2ObjectOpenHashMap<String, Object2ObjectOpenHashMap<String, DefCveItem>> cves,
+    @SuppressFBWarnings(value = "DM_GC", justification = "Manual collection preserves existing mirror memory behavior.")
+    void writeJsonMirror(Object2ObjectOpenHashMap<String, Object2ObjectOpenHashMap<String, DefCveItem>> cves,
             ZonedDateTime lastModified, int writeThreshold) {
         final String format = "NVD_CVE";
         final String version = "2.0";
         final String prefix = properties.get("prefix", "nvdcve-");
 
-        List<String> sortedKeys = new ArrayList<>(cves.keySet());
-        sortedKeys.sort((k1, k2) -> k2.compareTo(k1));
+        NavigableMap<String, Object2ObjectOpenHashMap<String, DefCveItem>> sortedCves = new TreeMap<>(
+                (k1, k2) -> k2.compareTo(k1));
+        sortedCves.putAll(cves);
 
         // flush older data after we find an entry that meets the threshold; meaning if 2020
         // meets the threshold and 2019 still have 500 entries - write the 500 entries
         boolean flushOlder = false;
-        for (String key : sortedKeys) {
-            Object2ObjectOpenHashMap<String, DefCveItem> cveApiData = cves.get(key);
+        for (Map.Entry<String, Object2ObjectOpenHashMap<String, DefCveItem>> entry : sortedCves.entrySet()) {
+            String key = entry.getKey();
+            Object2ObjectOpenHashMap<String, DefCveItem> cveApiData = entry.getValue();
             if ((cveApiData.isEmpty() || cveApiData.size() < writeThreshold)
                     && !(flushOlder && !cveApiData.isEmpty())) {
                 continue;
             }
             flushOlder = true;
             final File file = new File(properties.getDirectory(), prefix + key + ".json.gz");
+            final File tempFile = new File(properties.getDirectory(), prefix + key + ".json.gz.tmp");
             final File meta = new File(properties.getDirectory(), prefix + key + ".meta");
-            final Object2ObjectOpenHashMap<String, DefCveItem> yearData = new Object2ObjectOpenHashMap<>();
-            // Load existing year data if present
-            if (file.isFile()) {
-                try (FileInputStream fis = new FileInputStream(file); GZIPInputStream gzis = new GZIPInputStream(fis)) {
-                    CveApiJson20 data = objectMapper.readValue(gzis, CveApiJson20.class);
-                    boolean isYearData = !MODIFIED.equals(key);
-                    // filter the "modified" data to load only the last 7 days of data
-                    data.getVulnerabilities().stream().filter(cve -> isYearData
-                            || ChronoUnit.DAYS.between(cve.getCve().getLastModified(), ZonedDateTime.now()) <= 7)
-                            .forEach(cve -> yearData.put(cve.getCve().getId(), cve));
-                } catch (IOException exception) {
-                    throw new CacheException("Unable to read cached data: " + file, exception);
-                }
-            }
+            final NavigableMap<String, DefCveItem> updates = new TreeMap<>();
             synchronized (cves) {
-                yearData.putAll(cveApiData);
+                updates.putAll(cveApiData);
                 cveApiData.clear();
             }
-
-            List<DefCveItem> vulnerabilities = new ArrayList<DefCveItem>(yearData.values());
-            vulnerabilities.sort((v1, v2) -> {
-                return v1.getCve().getId().compareTo(v2.getCve().getId());
-            });
-            ZonedDateTime timestamp;
-            Optional<ZonedDateTime> maxDate = vulnerabilities.stream().map(v -> v.getCve().getLastModified())
-                    .max(ZonedDateTime::compareTo);
-            if (maxDate.isPresent()) {
-                timestamp = maxDate.get();
-            } else if (lastModified != null) {
-                timestamp = lastModified;
-            } else {
-                timestamp = ZonedDateTime.now();
-            }
-            properties.set("lastModifiedDate." + key, timestamp);
-            int cveCount = vulnerabilities.size();
+            final ZonedDateTime filterTime = ZonedDateTime.now();
+            final MergeStats stats = calculateMergeStats(file, key, updates, lastModified, filterTime);
+            properties.set("lastModifiedDate." + key, stats.timestamp());
+            int cveCount = stats.count();
             cveCountPerYear.setCveCountPerYear(key, cveCount);
-            CveApiJson20 data = new CveApiJson20(cveCount, 0, cveCount, format, version, timestamp, vulnerabilities);
             MessageDigest md;
             try {
                 md = MessageDigest.getInstance("SHA-256");
@@ -342,32 +321,176 @@ public class NvdMirrorService {
                 throw new CacheException("Unable to calculate sha256 checksum", e);
             }
             long byteCount = 0;
-            try (FileOutputStream fileOutputStream = new FileOutputStream(file);
+            try (FileOutputStream fileOutputStream = new FileOutputStream(tempFile);
                     GZIPOutputStream gzipOutputStream = new GZIPOutputStream(fileOutputStream);
                     DigestOutputStream digestOutputStream = new DigestOutputStream(gzipOutputStream, md);
                     CountingOutputStream countingOutputStream = new CountingOutputStream(digestOutputStream);
                     BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(countingOutputStream,
                             BUFFER_SIZE)) {
-                objectMapper.writeValue(bufferedOutputStream, data);
+                writeMirrorJson(bufferedOutputStream, file, key, updates, format, version, stats, filterTime);
                 byteCount = countingOutputStream.getByteCount();
             } catch (IOException ex) {
                 throw new CacheException("Unable to write cached data: " + file, ex);
             }
-            yearData.clear();
-            vulnerabilities.clear();
+            moveTempFile(tempFile, file);
             System.gc();
             String checksum = HexUtil.getHex(md.digest());
             try (FileOutputStream fileOutputStream = new FileOutputStream(meta);
                     OutputStreamWriter osw = new OutputStreamWriter(fileOutputStream, StandardCharsets.UTF_8);
                     PrintWriter writer = new PrintWriter(osw)) {
-                final String lmd = DateTimeFormatter.ISO_DATE_TIME.format(timestamp);
+                final String lmd = DateTimeFormatter.ISO_DATE_TIME.format(stats.timestamp());
                 writer.println("lastModifiedDate:" + lmd);
+                writer.println("cveCount:" + cveCount);
                 writer.println("size:" + byteCount);
                 writer.println("gzSize:" + file.length());
                 writer.println("sha256:" + checksum);
             } catch (IOException ex) {
                 throw new CacheException("Unable to write cached meta-data: " + file, ex);
             }
+        }
+    }
+
+    private MergeStats calculateMergeStats(File existingFile, String key, NavigableMap<String, DefCveItem> updates,
+            ZonedDateTime lastModified, ZonedDateTime filterTime) {
+        MergeStats stats = new MergeStats();
+        try {
+            mergeCves(existingFile, key, updates, filterTime, cve -> {
+                stats.count++;
+                ZonedDateTime modified = cve.getCve().getLastModified();
+                if (stats.maxDate == null || modified.compareTo(stats.maxDate) > 0) {
+                    stats.maxDate = modified;
+                }
+            });
+        } catch (IOException exception) {
+            throw new CacheException("Unable to read cached data: " + existingFile, exception);
+        }
+        if (stats.maxDate != null) {
+            stats.timestamp = stats.maxDate;
+        } else if (lastModified != null) {
+            stats.timestamp = lastModified;
+        } else {
+            stats.timestamp = filterTime;
+        }
+        return stats;
+    }
+
+    private void writeMirrorJson(BufferedOutputStream output, File existingFile, String key,
+            NavigableMap<String, DefCveItem> updates, String format, String version, MergeStats stats,
+            ZonedDateTime filterTime) throws IOException {
+        try (var jsonOut = objectMapper.getFactory().createGenerator(output)) {
+            jsonOut.writeStartObject();
+            jsonOut.writeNumberField("resultsPerPage", stats.count());
+            jsonOut.writeNumberField("startIndex", 0);
+            jsonOut.writeNumberField("totalResults", stats.count());
+            jsonOut.writeStringField("format", format);
+            jsonOut.writeStringField("version", version);
+            jsonOut.writeObjectField("timestamp", stats.timestamp());
+            jsonOut.writeFieldName("vulnerabilities");
+            jsonOut.writeStartArray();
+            mergeCves(existingFile, key, updates, filterTime, jsonOut::writeObject);
+            jsonOut.writeEndArray();
+            jsonOut.writeEndObject();
+        }
+    }
+
+    private void mergeCves(File existingFile, String key, NavigableMap<String, DefCveItem> updates,
+            ZonedDateTime filterTime, CveConsumer consumer) throws IOException {
+        Iterator<Map.Entry<String, DefCveItem>> updateIterator = updates.entrySet().iterator();
+        Map.Entry<String, DefCveItem> update = nextIncluded(updateIterator, key, filterTime);
+        if (existingFile.isFile()) {
+            try (FileInputStream fis = new FileInputStream(existingFile);
+                    GZIPInputStream gzis = new GZIPInputStream(fis);
+                    var parser = objectMapper.getFactory().createParser(gzis)) {
+                while (parser.nextToken() != null) {
+                    if (parser.currentToken() != com.fasterxml.jackson.core.JsonToken.FIELD_NAME
+                            || !"vulnerabilities".equals(parser.currentName())) {
+                        continue;
+                    }
+                    parser.nextToken();
+                    while (parser.nextToken() == com.fasterxml.jackson.core.JsonToken.START_OBJECT) {
+                        DefCveItem existing = objectMapper.readValue(parser, DefCveItem.class);
+                        if (!includeCve(key, existing, filterTime)) {
+                            continue;
+                        }
+                        String existingId = existing.getCve().getId();
+                        while (update != null && update.getKey().compareTo(existingId) < 0) {
+                            consumer.accept(update.getValue());
+                            update = nextIncluded(updateIterator, key, filterTime);
+                        }
+                        if (update != null && update.getKey().equals(existingId)) {
+                            consumer.accept(update.getValue());
+                            update = nextIncluded(updateIterator, key, filterTime);
+                        } else {
+                            consumer.accept(existing);
+                        }
+                    }
+                }
+            } catch (IOException exception) {
+                throw new CacheException("Unable to read cached data: " + existingFile, exception);
+            }
+        }
+        while (update != null) {
+            consumer.accept(update.getValue());
+            update = nextIncluded(updateIterator, key, filterTime);
+        }
+    }
+
+    private void moveTempFile(File tempFile, File targetFile) {
+        Path tempPath = tempFile.toPath();
+        Path targetPath = targetFile.toPath();
+        try {
+            Files.move(tempPath, targetPath, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException atomicException) {
+            moveTempFileWithoutAtomicMove(tempPath, targetPath, targetFile, atomicException);
+        }
+    }
+
+    private void moveTempFileWithoutAtomicMove(Path tempPath, Path targetPath, File targetFile,
+            IOException atomicException) {
+        try {
+            Files.move(tempPath, targetPath, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException replaceException) {
+            replaceException.addSuppressed(atomicException);
+            try {
+                Files.deleteIfExists(targetPath);
+                Files.move(tempPath, targetPath);
+            } catch (IOException exception) {
+                exception.addSuppressed(replaceException);
+                throw new CacheException("Unable to replace cached data: " + targetFile, exception);
+            }
+        }
+    }
+
+    private Map.Entry<String, DefCveItem> nextIncluded(Iterator<Map.Entry<String, DefCveItem>> iterator, String key,
+            ZonedDateTime filterTime) {
+        while (iterator.hasNext()) {
+            Map.Entry<String, DefCveItem> next = iterator.next();
+            if (includeCve(key, next.getValue(), filterTime)) {
+                return next;
+            }
+        }
+        return null;
+    }
+
+    private boolean includeCve(String key, DefCveItem item, ZonedDateTime filterTime) {
+        return !MODIFIED.equals(key) || ChronoUnit.DAYS.between(item.getCve().getLastModified(), filterTime) <= 7;
+    }
+
+    private interface CveConsumer {
+        void accept(DefCveItem item) throws IOException;
+    }
+
+    private static class MergeStats {
+        private int count;
+        private ZonedDateTime maxDate;
+        private ZonedDateTime timestamp;
+
+        int count() {
+            return count;
+        }
+
+        ZonedDateTime timestamp() {
+            return timestamp;
         }
     }
 

--- a/src/test/java/io/github/jeremylong/vulnz/cli/monitoring/CveCounterPerYearTest.java
+++ b/src/test/java/io/github/jeremylong/vulnz/cli/monitoring/CveCounterPerYearTest.java
@@ -1,0 +1,55 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2026 Jeremy Long. All Rights Reserved.
+ */
+package io.github.jeremylong.vulnz.cli.monitoring;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.jeremylong.openvulnerability.client.nvd.DefCveItem;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CveCounterPerYearTest {
+    @TempDir
+    private File directory;
+
+    @Test
+    void shouldReadCountFromMetaBeforeStreamingJson() throws Exception {
+        Files.writeString(new File(directory, "nvdcve-2025.json.gz").toPath(), "not a gzip", StandardCharsets.UTF_8);
+        Files.writeString(new File(directory, "nvdcve-2025.meta").toPath(),
+                "lastModifiedDate:2025-01-01T00:00:00Z\n" + "cveCount:1234\nsize:0\ngzSize:0\nsha256:abc\n",
+                StandardCharsets.UTF_8);
+        Object2ObjectOpenHashMap<String, Object2ObjectOpenHashMap<String, DefCveItem>> cves = new Object2ObjectOpenHashMap<>();
+        cves.put("2025", new Object2ObjectOpenHashMap<>());
+
+        CveCounterPerYear counter = new CveCounterPerYear(directory, "nvdcve-");
+        counter.initCveCountPerYear(cves);
+        counter.writeCveCountPerYear();
+
+        Map<String, Integer> counts = new ObjectMapper().readValue(new File(directory, "cve-count-per-year.json"),
+                new TypeReference<>() {
+                });
+        assertThat(counts).containsEntry("2025", 1234);
+    }
+}

--- a/src/test/java/io/github/jeremylong/vulnz/cli/services/NvdMirrorServiceTest.java
+++ b/src/test/java/io/github/jeremylong/vulnz/cli/services/NvdMirrorServiceTest.java
@@ -1,0 +1,126 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2026 Jeremy Long. All Rights Reserved.
+ */
+package io.github.jeremylong.vulnz.cli.services;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.github.jeremylong.openvulnerability.client.nvd.CveApiJson20;
+import io.github.jeremylong.openvulnerability.client.nvd.CveItem;
+import io.github.jeremylong.openvulnerability.client.nvd.DefCveItem;
+import io.github.jeremylong.openvulnerability.client.nvd.LangString;
+import io.github.jeremylong.openvulnerability.client.nvd.NvdCveClientBuilder;
+import io.github.jeremylong.openvulnerability.client.nvd.Reference;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.zip.GZIPInputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NvdMirrorServiceTest {
+    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    @TempDir
+    private File directory;
+
+    @Test
+    void shouldStreamMergeExistingDataWithSortedUpdates() throws Exception {
+        NvdMirrorService service = newService();
+        Object2ObjectOpenHashMap<String, Object2ObjectOpenHashMap<String, DefCveItem>> cves = cvesByGroup();
+        cves.get("2025").put("CVE-2025-0001", cve("CVE-2025-0001", "first", ZonedDateTime.now().minusDays(4)));
+        cves.get("2025").put("CVE-2025-0003", cve("CVE-2025-0003", "stale", ZonedDateTime.now().minusDays(3)));
+        service.writeJsonMirror(cves, null, 0);
+
+        cves.get("2025").put("CVE-2025-0002", cve("CVE-2025-0002", "second", ZonedDateTime.now().minusDays(2)));
+        cves.get("2025").put("CVE-2025-0003", cve("CVE-2025-0003", "replacement", ZonedDateTime.now().minusDays(1)));
+        service.writeJsonMirror(cves, null, 0);
+
+        CveApiJson20 data = read("nvdcve-2025.json.gz");
+        assertThat(data.getVulnerabilities()).extracting(cve -> cve.getCve().getId()).containsExactly("CVE-2025-0001",
+                "CVE-2025-0002", "CVE-2025-0003");
+        assertThat(data.getVulnerabilities().get(2).getCve().getDescriptions().get(0).getValue())
+                .isEqualTo("replacement");
+        assertThat(Files.readString(new File(directory, "nvdcve-2025.meta").toPath(), StandardCharsets.UTF_8))
+                .contains("cveCount:3");
+    }
+
+    @Test
+    void shouldFilterModifiedCacheToRecentCves() throws Exception {
+        NvdMirrorService service = newService();
+        Object2ObjectOpenHashMap<String, Object2ObjectOpenHashMap<String, DefCveItem>> cves = cvesByGroup();
+        cves.get(NvdMirrorService.MODIFIED).put("CVE-2025-0001",
+                cve("CVE-2025-0001", "old", ZonedDateTime.now().minusDays(10)));
+        cves.get(NvdMirrorService.MODIFIED).put("CVE-2025-0002",
+                cve("CVE-2025-0002", "recent", ZonedDateTime.now().minusDays(1)));
+
+        service.writeJsonMirror(cves, null, 0);
+
+        CveApiJson20 data = read("nvdcve-modified.json.gz");
+        assertThat(data.getVulnerabilities()).extracting(cve -> cve.getCve().getId()).containsExactly("CVE-2025-0002");
+        assertThat(Files.readString(new File(directory, "nvdcve-modified.meta").toPath(), StandardCharsets.UTF_8))
+                .contains("cveCount:1");
+    }
+
+    @Test
+    void shouldRewriteLargeExistingCacheWithoutMaterializingYear() throws Exception {
+        NvdMirrorService service = newService();
+        Object2ObjectOpenHashMap<String, Object2ObjectOpenHashMap<String, DefCveItem>> cves = cvesByGroup();
+        for (int i = 0; i < 5000; i++) {
+            String id = "CVE-2025-" + String.format("%04d", i);
+            cves.get("2025").put(id, cve(id, "initial-" + i, ZonedDateTime.now().minusDays(5)));
+        }
+        service.writeJsonMirror(cves, null, 0);
+
+        cves.get("2025").put("CVE-2025-5000", cve("CVE-2025-5000", "appended", ZonedDateTime.now().minusDays(1)));
+        service.writeJsonMirror(cves, null, 0);
+
+        CveApiJson20 data = read("nvdcve-2025.json.gz");
+        assertThat(data.getVulnerabilities()).hasSize(5001);
+        assertThat(data.getVulnerabilities().get(5000).getCve().getId()).isEqualTo("CVE-2025-5000");
+    }
+
+    private NvdMirrorService newService() {
+        return new NvdMirrorService(directory, "nvdcve-", NvdCveClientBuilder.aNvdCveApi(), false);
+    }
+
+    private Object2ObjectOpenHashMap<String, Object2ObjectOpenHashMap<String, DefCveItem>> cvesByGroup() {
+        Object2ObjectOpenHashMap<String, Object2ObjectOpenHashMap<String, DefCveItem>> cves = new Object2ObjectOpenHashMap<>();
+        cves.put(NvdMirrorService.MODIFIED, new Object2ObjectOpenHashMap<>());
+        cves.put("2025", new Object2ObjectOpenHashMap<>());
+        return cves;
+    }
+
+    private DefCveItem cve(String id, String description, ZonedDateTime lastModified) {
+        CveItem cve = new CveItem(id, ZonedDateTime.parse("2025-01-01T00:00:00Z"), lastModified,
+                List.of(new LangString("en", description)), List.of(new Reference("https://example.com/" + id)));
+        return new DefCveItem(cve);
+    }
+
+    private CveApiJson20 read(String fileName) throws Exception {
+        try (FileInputStream fis = new FileInputStream(new File(directory, fileName));
+                GZIPInputStream gzis = new GZIPInputStream(fis)) {
+            return objectMapper.readValue(gzis, CveApiJson20.class);
+        }
+    }
+}


### PR DESCRIPTION
As of late the NVD service has been returning 503 responses despite valid API keys. While setting up an NVD proxy, our build node also hit Java heap OOMs with max heap set to 2G..

```
 Caused by: java.lang.OutOfMemoryError: Java heap space
 	at java.base/java.lang.StringUTF16.compress(StringUTF16.java:161)
 	at java.base/java.lang.String.<init>(String.java:4501)
 	at java.base/java.lang.String.<init>(String.java:300)
 	at com.fasterxml.jackson.core.util.TextBuffer.setCurrentAndReturn(TextBuffer.java:996)
 	at com.fasterxml.jackson.core.json.UTF8StreamJsonParser._finishAndReturnString(UTF8StreamJsonParser.java:2512)
 	at com.fasterxml.jackson.core.json.UTF8StreamJsonParser.getText(UTF8StreamJsonParser.java:294)
 	at com.fasterxml.jackson.databind.deser.std.StringDeserializer.deserialize(StringDeserializer.java:42)
 	at com.fasterxml.jackson.databind.deser.std.StringDeserializer.deserialize(StringDeserializer.java:11)
 	at com.fasterxml.jackson.databind.deser.SettableBeanProperty.deserialize(SettableBeanProperty.java:543)
 	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeWithErrorWrapping(BeanDeserializer.java:585)
 	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeUsingPropertyBased(BeanDeserializer.java:447)
 	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1497)
 	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:348)
 	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:185)
 	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer._deserializeFromArray(CollectionDeserializer.java:361)
 	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:246)
 	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:30)
 	at com.fasterxml.jackson.databind.deser.SettableBeanProperty.deserialize(SettableBeanProperty.java:543)
 	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeWithErrorWrapping(BeanDeserializer.java:585)
 	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeUsingPropertyBased(BeanDeserializer.java:447)
 	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1497)
 	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:348)
 	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:185)
 	at com.fasterxml.jackson.databind.deser.SettableBeanProperty.deserialize(SettableBeanProperty.java:543)
 	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeWithErrorWrapping(BeanDeserializer.java:585)
 	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeUsingPropertyBased(BeanDeserializer.java:447)
 	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1497)
 	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:348)
 	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:185)
 	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer._deserializeFromArray(CollectionDeserializer.java:361)
 	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:246)
 	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:30)
```

MAT analysis showed the mirror update path materialized full yearly NVD cache files into Java objects, then copied them into additional map/list structures before writing. This made memory scale with full cache size, not update size.

Before, synthetic 120k CVE cache update:
- `-Xmx128m`: OOM in Jackson `PropertyValueBuffer`
- live merge heap dump: 258MB
- MAT retained set: 194.6MB
- retained objects: 3,938,347
- retained `CveItem`: 120,000

After, same synthetic 120k CVE cache update:
- `-Xmx64m`: completed
- live heap dump: 14MB
- MAT retained set: 7.6MB
- retained objects: 114,347
- no full-year `CveItem` graph retained